### PR TITLE
Fix Carousel autoplay interval

### DIFF
--- a/components/Carousel.jsx
+++ b/components/Carousel.jsx
@@ -19,7 +19,7 @@ function Carousel() {
 			setActiveIndex((prevIndex) =>
 				prevIndex === lastIndex ? 0 : prevIndex + 1
 			);
-		}, 500000);
+                }, 5000);
 
 		return () => clearInterval(autoPlay);
 	}, [lastIndex]);


### PR DESCRIPTION
## Summary
- adjust autoplay delay in `Carousel.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d1f0693f88331be6ae2e62c045ddd

## Summary by Sourcery

Bug Fixes:
- Reduce Carousel autoplay interval from 500000ms to 5000ms