### PR TITLE
Use env vars in email config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_EMAIL_SERVICE_ID=your_service_id
+VITE_EMAIL_TEMPLATE_ID=your_template_id
+VITE_EMAIL_PUBLIC_KEY=your_public_key

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
+.env.*
+!.env.example
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # React + Vite
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This template provides a minimal setup to get React working in Vite with HMR and
+some ESLint rules.
 
 Currently, two official plugins are available:
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md)
+  uses [Babel](https://babeljs.io/) for Fast Refresh
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc)
+  uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Environment variables
+
+The contact form uses EmailJS. Create a `.env` file at the project root with the
+following variables:
+
+```bash
+VITE_EMAIL_SERVICE_ID=your_service_id
+VITE_EMAIL_TEMPLATE_ID=your_template_id
+VITE_EMAIL_PUBLIC_KEY=your_public_key
+```
+
+An example configuration is available in `.env.example`.

--- a/components/Contact.jsx
+++ b/components/Contact.jsx
@@ -26,9 +26,9 @@ const Contact = () => {
 		e.preventDefault();
 		setIsSending(true);
 
-		const serviceID = 'service_lbs66wd';
-		const templateID = 'template_bdtxh17';
-		const publicKey = 'eESU8_c7bEh5fhZSb';
+                const serviceID = import.meta.env.VITE_EMAIL_SERVICE_ID;
+                const templateID = import.meta.env.VITE_EMAIL_TEMPLATE_ID;
+                const publicKey = import.meta.env.VITE_EMAIL_PUBLIC_KEY;
 
 		const templateParams = {
 			from_name: formData.from_name,


### PR DESCRIPTION
## Summary
- inject EmailJS IDs using env vars
- document required variables
- provide `.env.example`
- ignore `.env` files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d1f076cc48331bbe843c8f110223b

## Summary by Sourcery

Switch the contact form’s EmailJS configuration to use environment variables; update project documentation and ignore rules to support the new setup

New Features:
- Configure EmailJS service, template, and public key values via Vite environment variables

Documentation:
- Document the required VITE_EMAIL_* environment variables in README and provide an .env.example file

Chores:
- Add .env.example and update .gitignore to ignore .env files